### PR TITLE
Implement `Default` for `HttpBody1ToHttpBody04`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -169,3 +169,9 @@ where
         self.body.is_end_stream()
     }
 }
+
+impl<B: Default> Default for HttpBody1ToHttpBody04<B> {
+    fn default() -> Self {
+        HttpBody1ToHttpBody04::new(B::default())
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -78,7 +78,7 @@ pin_project! {
     ///
     /// [http-body 0.4 `Body`]: https://docs.rs/http-body/latest/http_body/trait.Body.html
     /// [http-body 1.0 `Body`]: https://docs.rs/http-body/1.0.0-rc.2/http_body/trait.Body.html
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Default)]
     pub struct HttpBody1ToHttpBody04<B> {
         #[pin]
         body: B,
@@ -167,11 +167,5 @@ where
     #[inline]
     fn is_end_stream(&self) -> bool {
         self.body.is_end_stream()
-    }
-}
-
-impl<B: Default> Default for HttpBody1ToHttpBody04<B> {
-    fn default() -> Self {
-        HttpBody1ToHttpBody04::new(B::default())
     }
 }


### PR DESCRIPTION
see https://github.com/hyperium/tonic/issues/1307

Tonic interceptors require a Default on the body. This makes it easier to use an adapter type tonic.

FWIW the default type I am using:

```rust

#[derive(Default)]
pub enum DefaultIncoming {
    Some(Incoming),
    #[default]
    Empty
}

impl Body for DefaultIncoming {
    type Data = Bytes;
    type Error = hyper::Error;

    fn poll_frame(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
        match self.get_mut() {
            DefaultIncoming::Some(ref mut i) => Pin::new(i).poll_frame(cx),
            DefaultIncoming::Empty => Pin::new(&mut http_body_util::Empty::<Bytes>::new()).poll_frame(cx).map_err(|_| unreachable!())
        }
    }
}
```