### PR TITLE
Upgrade to hyper 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ server = ["hyper-1/server"]
 client = ["hyper-1/client"]
 
 [dependencies]
-http = "0.2.9"
+http-02 = { package = "http", version = "0.2.9" }
+http-1 = { package = "http", version = "1.0" }
 http-body-04 = { package = "http-body", version = "0.4" }
-http-body-1 = { package = "http-body", version = "1.0.0-rc.2" } # remember to update README.md
-hyper-1 = { package = "hyper", version = "1.0.0-rc.4" } # remember to update README.md
+http-body-1 = { package = "http-body", version = "1.0" } # remember to update README.md
+hyper-1 = { package = "hyper", version = "1.0" } # remember to update README.md
 pin-project-lite = "0.2.9"
 tower = { version = "0.4", features = ["util"] }
 tower-service-03 = { package = "tower-service", version = "0.3" }
@@ -29,8 +30,8 @@ tower-service-03 = { package = "tower-service", version = "0.3" }
 axum = "0.6"
 bytes = "1.0"
 hyper-014 = { package = "hyper", version = "0.14", features = ["full"] }
-hyper-1 = { package = "hyper", version = "1.0.0-rc.4", features = ["full"] }
-http-body-util = "0.1.0-rc.2"
+hyper-1 = { package = "hyper", version = "1.0", features = ["full"] }
+http-body-util = "0.1.0"
 hyper-util = { git = "https://github.com/hyperium/hyper-util", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4", features = ["full", "make"] }

--- a/src/body.rs
+++ b/src/body.rs
@@ -174,6 +174,7 @@ where
     }
 }
 
+// http1_headermap_to_http02 converts an http-1.0 HeaderMap to an http-0.2 HeaderMap.
 fn http1_headermap_to_http02(h: http_1::HeaderMap) -> http_02::HeaderMap {
     let mut hm = http_02::HeaderMap::new();
     for (k, v) in h {
@@ -185,6 +186,7 @@ fn http1_headermap_to_http02(h: http_1::HeaderMap) -> http_02::HeaderMap {
     hm
 }
 
+// http02_headermap_to_http1 converts an http-0.2 HeaderMap to an http-1.0 HeaderMap.
 fn http02_headermap_to_http1(h: http_02::HeaderMap) -> http_1::HeaderMap {
     let mut hm = http_1::HeaderMap::new();
     for (k, v) in h {
@@ -196,6 +198,8 @@ fn http02_headermap_to_http1(h: http_02::HeaderMap) -> http_1::HeaderMap {
     hm
 }
 
+// http1_request_to_http02 converts an http-1.0 Request to an http-0.2 Request.
+// Warning: this conversion is lossy. The Extension field of the request will be lost.
 pub fn http1_request_to_http02<B>(r: http_1::Request<B>) -> http_02::Request<B> {
     let (head, body) = r.into_parts();
     let mut build = http_02::request::Builder::new()
@@ -212,12 +216,12 @@ pub fn http1_request_to_http02<B>(r: http_1::Request<B>) -> http_02::Request<B> 
     for (k, v) in head.headers {
         build = build.header(k.unwrap().as_str(), v.as_ref())
     }
-    // for v in head.extension {
-    //     build = build.extension(v)
-    // }
+    // TODO: there is not a way to convert extension over
     build.body(body).unwrap()
 }
 
+// http1_response_to_http02 converts an http-1.0 Response to an http-0.2 Response.
+// Warning: this conversion is lossy. The Extension field of the response will be lost.
 pub fn http1_response_to_http02<B>(r: http_1::Response<B>) -> http_02::Response<B> {
     let (head, body) = r.into_parts();
     let mut build = http_02::response::Builder::new()
@@ -233,12 +237,12 @@ pub fn http1_response_to_http02<B>(r: http_1::Response<B>) -> http_02::Response<
     for (k, v) in head.headers {
         build = build.header(k.unwrap().as_str(), v.as_ref())
     }
-    // for v in head.extension {
-    //     build = build.extension(v)
-    // }
+    // TODO: there is not a way to convert extension over
     build.body(body).unwrap()
 }
 
+// http02_request_to_http1 converts an http-0.2 Request to an http-1.0 Request.
+// Warning: this conversion is lossy. The Extension field of the request will be lost.
 pub fn http02_request_to_http1<B>(r: http_02::Request<B>) -> http_1::Request<B> {
     let (head, body) = r.into_parts();
     let mut build = http_1::request::Builder::new()
@@ -255,12 +259,12 @@ pub fn http02_request_to_http1<B>(r: http_02::Request<B>) -> http_1::Request<B> 
     for (k, v) in head.headers {
         build = build.header(k.unwrap().as_str(), v.as_ref())
     }
-    // for v in head.extension {
-    //     build = build.extension(v)
-    // }
+    // TODO: there is not a way to convert extension over
     build.body(body).unwrap()
 }
 
+// http02_request_to_http1 converts an http-0.2 Response to an http-1.0 Response.
+// Warning: this conversion is lossy. The Extension field of the response will be lost.
 pub fn http02_response_to_http1<B>(r: http_02::Response<B>) -> http_1::Response<B> {
     let (head, body) = r.into_parts();
     let mut build = http_1::response::Builder::new()
@@ -276,8 +280,6 @@ pub fn http02_response_to_http1<B>(r: http_02::Response<B>) -> http_1::Response<
     for (k, v) in head.headers {
         build = build.header(k.unwrap().as_str(), v.as_ref())
     }
-    // for v in head.extension {
-    //     build = build.extension(v)
-    // }
+    // TODO: there is not a way to convert extension over
     build.body(body).unwrap()
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -181,3 +181,31 @@ fn http02_headermap_to_http1(h: http_02::HeaderMap) -> http_1::HeaderMap {
         std::mem::transmute::<http_02::HeaderMap, http_1::HeaderMap>(h)
     }
 }
+
+pub fn http1_request_to_http02<B>(r: http_1::Request<B>) -> http_02::Request<B> {
+    let (head, body) = r.into_parts();
+    unsafe {
+        http_02::Request::from_parts(std::mem::transmute::<_, http_02::request::Parts>(head), body)
+    }
+}
+
+pub fn http1_response_to_http02<B>(r: http_1::Response<B>) -> http_02::Response<B> {
+    let (head, body) = r.into_parts();
+    unsafe {
+        http_02::Response::from_parts(std::mem::transmute::<_, http_02::response::Parts>(head), body)
+    }
+}
+
+pub fn http02_request_to_http1<B>(r: http_02::Request<B>) -> http_1::Request<B> {
+    let (head, body) = r.into_parts();
+    unsafe {
+        http_1::Request::from_parts(std::mem::transmute::<_, http_1::request::Parts>(head), body)
+    }
+}
+
+pub fn http02_response_to_http1<B>(r: http_02::Response<B>) -> http_1::Response<B> {
+    let (head, body) = r.into_parts();
+    unsafe {
+        http_1::Response::from_parts(std::mem::transmute::<_, http_1::response::Parts>(head), body)
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -174,7 +174,7 @@ where
     }
 }
 
-// http1_headermap_to_http02 converts an http-1.0 HeaderMap to an http-0.2 HeaderMap.
+/// http1_headermap_to_http02 converts an http-1.0 HeaderMap to an http-0.2 HeaderMap.
 fn http1_headermap_to_http02(h: http_1::HeaderMap) -> http_02::HeaderMap {
     let mut hm = http_02::HeaderMap::new();
     for (k, v) in h {
@@ -186,7 +186,7 @@ fn http1_headermap_to_http02(h: http_1::HeaderMap) -> http_02::HeaderMap {
     hm
 }
 
-// http02_headermap_to_http1 converts an http-0.2 HeaderMap to an http-1.0 HeaderMap.
+/// http02_headermap_to_http1 converts an http-0.2 HeaderMap to an http-1.0 HeaderMap.
 fn http02_headermap_to_http1(h: http_02::HeaderMap) -> http_1::HeaderMap {
     let mut hm = http_1::HeaderMap::new();
     for (k, v) in h {
@@ -198,8 +198,8 @@ fn http02_headermap_to_http1(h: http_02::HeaderMap) -> http_1::HeaderMap {
     hm
 }
 
-// http1_request_to_http02 converts an http-1.0 Request to an http-0.2 Request.
-// Warning: this conversion is lossy. The Extension field of the request will be lost.
+/// http1_request_to_http02 converts an http-1.0 Request to an http-0.2 Request.
+/// Warning: this conversion is lossy. The Extension field of the request will be lost.
 pub fn http1_request_to_http02<B>(r: http_1::Request<B>) -> http_02::Request<B> {
     let (head, body) = r.into_parts();
     let mut build = http_02::request::Builder::new()
@@ -220,8 +220,8 @@ pub fn http1_request_to_http02<B>(r: http_1::Request<B>) -> http_02::Request<B> 
     build.body(body).unwrap()
 }
 
-// http1_response_to_http02 converts an http-1.0 Response to an http-0.2 Response.
-// Warning: this conversion is lossy. The Extension field of the response will be lost.
+/// http1_response_to_http02 converts an http-1.0 Response to an http-0.2 Response.
+/// Warning: this conversion is lossy. The Extension field of the response will be lost.
 pub fn http1_response_to_http02<B>(r: http_1::Response<B>) -> http_02::Response<B> {
     let (head, body) = r.into_parts();
     let mut build = http_02::response::Builder::new()
@@ -241,8 +241,8 @@ pub fn http1_response_to_http02<B>(r: http_1::Response<B>) -> http_02::Response<
     build.body(body).unwrap()
 }
 
-// http02_request_to_http1 converts an http-0.2 Request to an http-1.0 Request.
-// Warning: this conversion is lossy. The Extension field of the request will be lost.
+/// http02_request_to_http1 converts an http-0.2 Request to an http-1.0 Request.
+/// Warning: this conversion is lossy. The Extension field of the request will be lost.
 pub fn http02_request_to_http1<B>(r: http_02::Request<B>) -> http_1::Request<B> {
     let (head, body) = r.into_parts();
     let mut build = http_1::request::Builder::new()
@@ -263,8 +263,8 @@ pub fn http02_request_to_http1<B>(r: http_02::Request<B>) -> http_1::Request<B> 
     build.body(body).unwrap()
 }
 
-// http02_request_to_http1 converts an http-0.2 Response to an http-1.0 Response.
-// Warning: this conversion is lossy. The Extension field of the response will be lost.
+/// http02_request_to_http1 converts an http-0.2 Response to an http-1.0 Response.
+/// Warning: this conversion is lossy. The Extension field of the response will be lost.
 pub fn http02_response_to_http1<B>(r: http_02::Response<B>) -> http_1::Response<B> {
     let (head, body) = r.into_parts();
     let mut build = http_1::response::Builder::new()

--- a/src/http_service.rs
+++ b/src/http_service.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use http::{Request, Response};
+use http_1::{Request, Response};
 use pin_project_lite::pin_project;
 use tower::{util::Oneshot, ServiceExt};
 

--- a/src/http_service.rs
+++ b/src/http_service.rs
@@ -15,20 +15,19 @@ use crate::{http02_request_to_http1, http02_response_to_http1, http1_request_to_
 
 /// Converts a [tower-service 0.3 HTTP `Service`] to a [hyper 1.0 HTTP `Service`].
 ///
-/// An HTTP `Service` is a `Service` where the request is [`http::Request<_>`][Request] and the
-/// response is [`http::Response<_>`][Response].
+/// An HTTP `Service` is a `Service` where the request is [`http::Request<_>`][http_1::Request] and the
+/// response is [`http::Response<_>`][http_1::Response].
 ///
 /// # Example
 ///
 /// ```no_run
-/// use http::{Request, Response, StatusCode};
 /// use hyper_1::{server::conn::http1, service::service_fn, body, body::Bytes};
 /// use std::{net::SocketAddr, convert::Infallible};
 /// use tokio::net::TcpListener;
 /// use tower_hyper_http_body_compat::TowerService03HttpServiceAsHyper1HttpService;
 ///
 /// // a service function that uses hyper 0.14, tower-service 0.3, and http-body 0.4
-/// async fn handler<B>(req: Request<B>) -> Result<Response<hyper_014::body::Body>, Infallible>
+/// async fn handler<B>(req: http_02::Request<B>) -> Result<http_02::Response<hyper_014::body::Body>, Infallible>
 /// where
 ///     B: hyper_014::body::HttpBody<Data = hyper_014::body::Bytes>,
 ///     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -38,15 +37,15 @@ use crate::{http02_request_to_http1, http02_response_to_http1, http1_request_to_
 ///    let bytes = match hyper_014::body::to_bytes(body).await {
 ///        Ok(bytes) => bytes,
 ///        Err(err) => {
-///            let res = Response::builder()
-///                .status(StatusCode::BAD_REQUEST)
+///            let res = http_02::Response::builder()
+///                .status(http_02::StatusCode::BAD_REQUEST)
 ///                .body(hyper_014::body::Body::empty())
 ///                .unwrap();
 ///            return Ok(res)
 ///        }
 ///    };
 ///
-///    let res = Response::builder()
+///    let res = http_02::Response::builder()
 ///        .body(hyper_014::body::Body::from(format!("Received {} bytes", bytes.len())))
 ///        .unwrap();
 ///    Ok(res)
@@ -172,8 +171,8 @@ where
 
 /// Converts a [hyper 1.0 HTTP `Service`] to a [tower-service 0.3 HTTP `Service`].
 ///
-/// An HTTP `Service` is a `Service` where the request is [`http::Request<_>`][Request] and the
-/// response is [`http::Response<_>`][Response].
+/// An HTTP `Service` is a `Service` where the request is [`http::Request<_>`][http_02::Request] and the
+/// response is [`http::Response<_>`][http_02::Response].
 ///
 /// [tower-service 0.3 HTTP `Service`]: https://docs.rs/tower-service/latest/tower_service/trait.Service.html
 /// [hyper 1.0 HTTP `Service`]: https://docs.rs/hyper/1.0.0-rc.4/hyper/service/trait.Service.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 )]
 #![deny(unreachable_pub, private_in_public)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
-// #![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 )]
 #![deny(unreachable_pub, private_in_public)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,9 @@ cfg_service! {
 
 mod body;
 
-pub use body::{HttpBody04ToHttpBody1, HttpBody1ToHttpBody04};
-pub use body::{http1_request_to_http02, http1_response_to_http02};
 pub use body::{http02_request_to_http1, http02_response_to_http1};
+pub use body::{http1_request_to_http02, http1_response_to_http02};
+pub use body::{HttpBody04ToHttpBody1, HttpBody1ToHttpBody04};
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ cfg_service! {
 mod body;
 
 pub use body::{HttpBody04ToHttpBody1, HttpBody1ToHttpBody04};
+pub use body::{http1_request_to_http02, http1_response_to_http02};
+pub use body::{http02_request_to_http1, http02_response_to_http1};
 
 #[cfg(test)]
 mod tests;

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,7 +12,7 @@ use tower::{util::Oneshot, ServiceExt};
 
 /// Converts a [tower-service 0.3 `Service`] to a [hyper 1.0 `Service`].
 ///
-/// If you have a service that uses [`http::Request`] and [`http::Response`] then you probaby need
+/// If you have a service that uses [`http_02::Request`] and [`http_02::Response`] then you probaby need
 /// [`TowerService03HttpServiceAsHyper1HttpService`] instead of this.
 ///
 /// [tower-service 0.3 `Service`]: https://docs.rs/tower-service/latest/tower_service/trait.Service.html
@@ -72,7 +72,7 @@ where
 
 /// Converts a [hyper 1.0 `Service`] to a [tower-service 0.3 `Service`].
 ///
-/// If you have a service that uses [`http::Request`] and [`http::Response`] then you probaby need
+/// If you have a service that uses [`http_1::Request`] and [`http_1::Response`] then you probaby need
 /// [`Hyper1HttpServiceAsTowerService03HttpService`] instead of this.
 ///
 /// [tower-service 0.3 `Service`]: https://docs.rs/tower-service/latest/tower_service/trait.Service.html

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,6 @@
 use std::convert::Infallible;
 
 use bytes::Bytes;
-use http::{Request, Response, StatusCode};
 use http_body_util::BodyExt;
 use hyper_1::server::conn::http1;
 use tokio::net::TcpListener;
@@ -10,7 +9,7 @@ use crate::*;
 
 #[tokio::test]
 async fn tower_service_03_service_to_hyper_1_service() {
-    async fn handle<B>(req: Request<B>) -> Result<Response<hyper_014::Body>, Infallible>
+    async fn handle<B>(req: http_02::Request<B>) -> Result<http_02::Response<hyper_014::Body>, Infallible>
     where
         B: http_body_04::Body,
     {
@@ -18,7 +17,7 @@ async fn tower_service_03_service_to_hyper_1_service() {
             .await
             .unwrap_or_else(|_| panic!());
         assert_eq!(bytes, "in");
-        Ok(Response::new(hyper_014::Body::from("out")))
+        Ok(http_02::Response::new(hyper_014::Body::from("out")))
     }
 
     let svc = tower::service_fn(handle);
@@ -42,7 +41,7 @@ async fn tower_service_03_service_to_hyper_1_service() {
     let client = hyper_014::Client::builder().build_http();
     let mut res = client
         .request(
-            Request::builder()
+            http_02::Request::builder()
                 .uri(format!("http://{addr}"))
                 .body(hyper_014::Body::from("in"))
                 .unwrap(),
@@ -50,7 +49,7 @@ async fn tower_service_03_service_to_hyper_1_service() {
         .await
         .unwrap();
 
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), http_02::StatusCode::OK);
 
     let bytes = hyper_014::body::to_bytes(&mut res).await.unwrap();
     assert_eq!(bytes, "out");
@@ -58,18 +57,18 @@ async fn tower_service_03_service_to_hyper_1_service() {
 
 #[tokio::test]
 async fn hyper_1_service_to_tower_service_03_service() {
-    async fn handle<B>(req: Request<B>) -> Result<Response<http_body_util::Full<Bytes>>, Infallible>
+    async fn handle<B>(req: http_1::Request<B>) -> Result<http_1::Response<http_body_util::Full<Bytes>>, Infallible>
     where
         B: http_body_1::Body,
     {
         let collected = req.into_body().collect().await.unwrap_or_else(|_| panic!());
         assert_eq!(collected.to_bytes(), "in");
 
-        Ok(Response::new(http_body_util::Full::new(Bytes::from("out"))))
+        Ok(http_1::Response::new(http_body_util::Full::new(Bytes::from("out"))))
     }
 
     let svc = hyper_1::service::service_fn(handle);
-    let svc = Hyper1HttpServiceAsTowerService03HttpService::new(svc);
+    let svc = crate::Hyper1HttpServiceAsTowerService03HttpService::new(svc);
 
     let tcp_listener = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
     let addr = tcp_listener.local_addr().unwrap();
@@ -84,7 +83,7 @@ async fn hyper_1_service_to_tower_service_03_service() {
     let client = hyper_014::Client::builder().build_http();
     let mut res = client
         .request(
-            Request::builder()
+            http_02::Request::builder()
                 .uri(format!("http://{addr}"))
                 .body(hyper_014::Body::from("in"))
                 .unwrap(),
@@ -92,7 +91,7 @@ async fn hyper_1_service_to_tower_service_03_service() {
         .await
         .unwrap();
 
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), http_02::StatusCode::OK);
 
     let bytes = hyper_014::body::to_bytes(&mut res).await.unwrap();
     assert_eq!(bytes, "out");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,9 @@ use crate::*;
 
 #[tokio::test]
 async fn tower_service_03_service_to_hyper_1_service() {
-    async fn handle<B>(req: http_02::Request<B>) -> Result<http_02::Response<hyper_014::Body>, Infallible>
+    async fn handle<B>(
+        req: http_02::Request<B>,
+    ) -> Result<http_02::Response<hyper_014::Body>, Infallible>
     where
         B: http_body_04::Body,
     {
@@ -57,18 +59,22 @@ async fn tower_service_03_service_to_hyper_1_service() {
 
 #[tokio::test]
 async fn hyper_1_service_to_tower_service_03_service() {
-    async fn handle<B>(req: http_1::Request<B>) -> Result<http_1::Response<http_body_util::Full<Bytes>>, Infallible>
+    async fn handle<B>(
+        req: http_1::Request<B>,
+    ) -> Result<http_1::Response<http_body_util::Full<Bytes>>, Infallible>
     where
         B: http_body_1::Body,
     {
         let collected = req.into_body().collect().await.unwrap_or_else(|_| panic!());
         assert_eq!(collected.to_bytes(), "in");
 
-        Ok(http_1::Response::new(http_body_util::Full::new(Bytes::from("out"))))
+        Ok(http_1::Response::new(http_body_util::Full::new(
+            Bytes::from("out"),
+        )))
     }
 
     let svc = hyper_1::service::service_fn(handle);
-    let svc = crate::Hyper1HttpServiceAsTowerService03HttpService::new(svc);
+    let svc = Hyper1HttpServiceAsTowerService03HttpService::new(svc);
 
     let tcp_listener = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
     let addr = tcp_listener.local_addr().unwrap();


### PR DESCRIPTION
Update to hyper 1.0.0.

This change is non trivial due to the bumping of `http`. To handle this, this PR introduces conversion functions for http0.2<->http1.0.

TODO:
* Remove unsafe -- I don't think there are any issues here, just did it to be quick; will fix up tomorrow hopefully
* Add more documentation
* Fix tests, maybe? I had issues running these from `main`, not sure if they are broken or its an issue on my side

cc @davidpdrsn  @luciofranco